### PR TITLE
UPT: Fix the max cap of the map

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -17,7 +17,7 @@ func Reverse(s []string) []string {
 }
 
 func GetFrequency(result []string) map[string]int {
-	resultMap := make(map[string]int, 0, len(result))
+	resultMap := make(map[string]int, len(result))
 
 	for _, v := range result {
 		if _, ok := resultMap[v]; ok {

--- a/utils.go
+++ b/utils.go
@@ -17,7 +17,7 @@ func Reverse(s []string) []string {
 }
 
 func GetFrequency(result []string) map[string]int {
-	resultMap := make(map[string]int)
+	resultMap := make(map[string]int, 0, len(result))
 
 	for _, v := range result {
 		if _, ok := resultMap[v]; ok {


### PR DESCRIPTION
# Feature
1. Fix the max cap of the map

# Objective
The max cap of the map should not more than scanned array. So we can set the max cap of the map